### PR TITLE
Fix WorkerReader behavior on massive data

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -1,2 +1,1 @@
 export { Queue } from "https://deno.land/x/async@v1.0/queue.ts";
-export { copy as copyBytes } from "https://deno.land/std@0.87.0/bytes/mod.ts";


### PR DESCRIPTION
This PR fix the behavior of `WorkerReader` when the data is larger than the buffer size.